### PR TITLE
fix data /ext4 to not forceencrypt

### DIFF
--- a/fstab.flounder
+++ b/fstab.flounder
@@ -7,7 +7,7 @@
 /dev/block/platform/sdhci-tegra.3/by-name/VNR   /vendor             ext4      ro                                                    wait
 /dev/block/platform/sdhci-tegra.3/by-name/CAC   /cache              ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic    wait,check
 /dev/block/platform/sdhci-tegra.3/by-name/UDA   /data               f2fs      noatime,nosuid,nodev,errors=recover    wait,check,encryptable=/dev/block/platform/sdhci-tegra.3/by-name/MD1
-/dev/block/platform/sdhci-tegra.3/by-name/UDA   /data               ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic    wait,check,forceencrypt=/dev/block/platform/sdhci-tegra.3/by-name/MD1
+/dev/block/platform/sdhci-tegra.3/by-name/UDA   /data               ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic    wait,check,encryptable=/dev/block/platform/sdhci-tegra.3/by-name/MD1
 /dev/block/platform/sdhci-tegra.3/by-name/LNX   /boot               emmc      defaults                                              defaults
 /dev/block/platform/sdhci-tegra.3/by-name/SOS   /recovery           emmc      defaults                                              defaults
 /dev/block/platform/sdhci-tegra.3/by-name/MSC   /misc               emmc      defaults                                              defaults


### PR DESCRIPTION
it turns out there are some Nexus 9s out there that have /data formatted to ext4